### PR TITLE
顧客登録時の郵便番号検索を実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "yubinbango-core2": "^0.6.3"
+            },
             "devDependencies": {
                 "@inertiajs/inertia": "^0.11.0",
                 "@inertiajs/inertia-vue3": "^0.6.0",
@@ -2909,6 +2912,12 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/yubinbango-core2": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/yubinbango-core2/-/yubinbango-core2-0.6.3.tgz",
+            "integrity": "sha512-wH+DE6PEQDTPKz/3dcs46yMXQzI99gL2tI+uhi5OtbvSKAd9WEx6lE6TtyumPCDQsHnej2WWjs904izJgfSHQg==",
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "@inertiajs/vue3": "^1.0.0",
         "@inertiajs/inertia": "^0.11.0",
         "@inertiajs/inertia-vue3": "^0.6.0",
+        "@inertiajs/vue3": "^1.0.0",
         "@tailwindcss/forms": "^0.5.3",
         "@vitejs/plugin-vue": "^4.0.0",
         "autoprefixer": "^10.4.12",
@@ -18,5 +18,8 @@
         "tailwindcss": "^3.2.1",
         "vite": "^4.0.0",
         "vue": "^3.2.41"
+    },
+    "dependencies": {
+        "yubinbango-core2": "^0.6.3"
     }
 }

--- a/resources/js/Pages/Customers/Create.vue
+++ b/resources/js/Pages/Customers/Create.vue
@@ -1,13 +1,22 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head } from '@inertiajs/vue3';
-
 import { reactive } from 'vue';
 import { Inertia } from '@inertiajs/inertia';
+import { Core as YubinBangoCore } from "yubinbango-core2";
 
 defineProps({
     errors: Object
 })
+
+// 数字を文字に変換 第１引数が郵便番号、第２がコールバックで引数に住所  
+const fetchAddress = () => { 
+    new YubinBangoCore(String(form.postcode), (value) => { 
+        console.log(value)
+        form.address = value.region + value.locality + value.street 
+    }) 
+
+} 
 
 const form = reactive({
      name: null,
@@ -80,7 +89,7 @@ const storeCustomer = () => {
                                                 <div class="relative">
                                                     <label for="postcode"
                                                         class="leading-7 text-sm text-gray-600">郵便番号</label>
-                                                    <input type="number" id="postcode" name="postcode" v-model="form.postcode"
+                                                    <input type="number" id="postcode" name="postcode" @change="fetchAddress" v-model="form.postcode"
                                                         class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
                                                 </div>
                                             </div>


### PR DESCRIPTION


### **実装のポイントを箇条書きで記載**
・Vue.jsで郵便番号検索をできるようにする場合、ライブラリを使用する（インストールコマンド：npm i yubinbango-core2@^0.6.3　インストールできたらpackage.jsonにライブラリが入っているか確認

・使用時は使用するvueファイルでインポート

・数字をStringに変換しないとうまくいかないらしい
// 数字を文字に変換 第１引数が郵便番号、第２がコールバックで引数に住所  
const fetchAddress = () => { 
    new YubinBangoCore(String(form.postcode), (value) => { 
        form.address = value.region + value.locality + value.street 
    }) 
} 
・第一引数に入力した郵便番号、第二引数に該当する住所が入る形となる

・「＠change」とすると入力欄からカーソルを外した瞬間にメソッドが走るような作りとなる

・「@chamge」とスペルミスがあった。スペルミスは適宜気を付けるようにする。